### PR TITLE
Updated EAV Attribute code max length

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute.php
@@ -23,7 +23,7 @@ class Attribute extends \Magento\Eav\Model\Entity\Attribute\AbstractAttribute im
     /**
      * Attribute code max length
      */
-    const ATTRIBUTE_CODE_MAX_LENGTH = 255;
+    const ATTRIBUTE_CODE_MAX_LENGTH = 60;
 
     /**
      * Cache tag


### PR DESCRIPTION
 - EAV attribute code will be transformed into column name for flat tables. MySQL does not support column name with more than 64 symbols

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Install magento 
2. enable flat more
3. make sure that catalog works on the frontend

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
